### PR TITLE
Correction on array for ProtoEnum

### DIFF
--- a/protobufjs/protobufjs-tests.ts
+++ b/protobufjs/protobufjs-tests.ts
@@ -180,7 +180,9 @@ function assertIsProtoEnum(pe: ProtoBuf.ProtoEnum, name: string) {
     assert.ok("values" in pe, name + " should contain property values");
     assert.ok("options" in pe, name + " should contain property options");
 
-    assertIsProtoEnumValue(pe.values, name + ".values");
+    for (var value in pe.values) {
+        assertIsProtoEnumValue(pe.values[value], name + ".values." + value);
+    }
 }
 
 function assertIsProtoEnumValue(pev: ProtoBuf.ProtoEnumValue, name: string) {

--- a/protobufjs/protobufjs.d.ts
+++ b/protobufjs/protobufjs.d.ts
@@ -224,7 +224,7 @@ declare namespace ProtoBuf {
 
     export interface ProtoEnum {
         name: string;
-        values: ProtoEnumValue;
+        values: ProtoEnumValue[];
         options: {[key: string]: any};
     }
 


### PR DESCRIPTION
The values field of the ProtoEnum interface should be an array not a single entry. This can be seen when using the Protobuf.js parser on enum fields where a file containing:

```

enum Priority {
    LOW = 1;
    MEDIUM = 2;
    HIGH = 3;
}
```

Is parsed to:

```
{ package: null,                                                             
  messages: [],                                                              
  enums:                                                                     
   [ { name: 'Priority',                                                     
       values:                                                               
        [ { name: 'LOW', id: 1 },                                            
          { name: 'MEDIUM', id: 2 },                                         
          { name: 'HIGH', id: 3 } ],                                         
       options: {} } ],                                                      
  imports: [],                                                               
  options: {},                                                               
  services: [] } 
```

see https://github.com/dcodeIO/ProtoBuf.js/wiki/Parser